### PR TITLE
Docker hub repository changed.

### DIFF
--- a/statefulset.yml
+++ b/statefulset.yml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 33
         runAsUser: 33
       containers:
-      - image: mprasil/bitwarden:latest
+      - image: bitwardenrs/server:latest
         imagePullPolicy: IfNotPresent
         name: bitwarden
         envFrom:


### PR DESCRIPTION
According to the former Docker Hub page (https://hub.docker.com/r/mprasil/bitwarden), project was moved to https://hub.docker.com/r/bitwardenrs/server.