### PR TITLE
fix statefulset.yml version

### DIFF
--- a/statefulset.yml
+++ b/statefulset.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: "apps/v1beta1"
+apiVersion: "apps/v1"
 kind: StatefulSet
 metadata:
   name: bitwarden


### PR DESCRIPTION
fix error: unable to recognize "kubernets/statefulset.yml": no matches for kind "StatefulSet" in version "apps/v1beta1"